### PR TITLE
Fix  gallery data-attr button

### DIFF
--- a/img/arrow-left.svg
+++ b/img/arrow-left.svg
@@ -1,4 +1,5 @@
-<svg id="arrow-left" data-name="Group 4" xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5">
+<svg id="arrow-left" data-name="Group 4" xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5"
+  data-event-category='Gellery' data-event-action='Click' data-event-label='Left'>
   <g id="Ellipse_1" data-name="Ellipse 1" fill="none" stroke="#707070" stroke-width="1">
     <circle cx="17.75" cy="17.75" r="17.75" stroke="none"/>
     <circle cx="17.75" cy="17.75" r="17.25" fill="none"/>

--- a/img/arrow-right.svg
+++ b/img/arrow-right.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5">
+<svg xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5"
+  data-event-category='Gellery' data-event-action='Click' data-event-label='Right'>
   <g id="arrow-right" data-name="Group 5" transform="translate(35.5 35.5) rotate(180)">
     <g id="Ellipse_1" data-name="Ellipse 1" fill="none" stroke="#707070" stroke-width="1">
       <circle cx="17.75" cy="17.75" r="17.75" stroke="none"/>

--- a/index.html
+++ b/index.html
@@ -130,7 +130,8 @@
         <div class="row justify-content-center reveal_bottom">
           <div class="col-12 col-md-10 col-lg-9 d-flex mt-5">
             <div class="swiper-button">
-              <div class="swiper-prev" data-event-category="Gellery" data-event-action="Click" data-event-label="Left"><svg id="arrow-left" data-name="Group 4" xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5">
+              <div class="swiper-prev"><svg id="arrow-left" data-name="Group 4" xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5"
+  data-event-category='Gellery' data-event-action='Click' data-event-label='Left'>
   <g id="Ellipse_1" data-name="Ellipse 1" fill="none" stroke="#707070" stroke-width="1">
     <circle cx="17.75" cy="17.75" r="17.75" stroke="none"/>
     <circle cx="17.75" cy="17.75" r="17.25" fill="none"/>
@@ -141,7 +142,8 @@
 </svg>
 
               </div>
-              <div class="swiper-next" data-event-category="Gellery" data-event-action="Click" data-event-label="Right"><svg xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5">
+              <div class="swiper-next"><svg xmlns="http://www.w3.org/2000/svg" width="35.5" height="35.5" viewBox="0 0 35.5 35.5"
+  data-event-category='Gellery' data-event-action='Click' data-event-label='Right'>
   <g id="arrow-right" data-name="Group 5" transform="translate(35.5 35.5) rotate(180)">
     <g id="Ellipse_1" data-name="Ellipse 1" fill="none" stroke="#707070" stroke-width="1">
       <circle cx="17.75" cy="17.75" r="17.75" stroke="none"/>

--- a/pug/partial/_gallery.pug
+++ b/pug/partial/_gallery.pug
@@ -26,10 +26,10 @@ section#gallery
         .row.justify-content-center.reveal_bottom
             .col-12.col-md-10.col-lg-9.d-flex.mt-5
                 .swiper-button
-                    .swiper-prev(data-event-category='Gellery' data-event-action='Click' data-event-label='Left')
+                    .swiper-prev
                         include ../../img/arrow-left.svg
 
-                    .swiper-next(data-event-category='Gellery' data-event-action='Click' data-event-label='Right')
+                    .swiper-next
                         include ../../img/arrow-right.svg
                 .see-more
                     p See more...


### PR DESCRIPTION
修正 Gallery  左右鍵的 `data-event-category` `data-event-action` 位置。
原先按鈕寫在外層 `div` 上，但 GTM 無法追蹤到，於是改寫在內層的 `SVG` 上才能追縱到點擊行為。